### PR TITLE
chore(release): update MTC/Crane PR-BZ map

### DIFF
--- a/MTC_MAP.md
+++ b/MTC_MAP.md
@@ -3,6 +3,6 @@
 This is the value last set in Konveyor's [BRANCH_TO_RELEASE](https://github.com/organizations/konveyor/settings/secrets/actions/BRANCH_TO_RELEASE) secret.
 
 ```
-'release-1.3.2:1.3.z,release-1.4.4:1.4.4,release-1.4.3:1.4.3,release-1.4.0:1.4.0,release-1.4.5:1.4.5,release-1.4.6:1.4.6,release-1.4.7:1.4.7,release-1.5.0:1.5.0,release-1.5.1:1.5.1,release-1.5.2:1.5.2,release-1.6.0:1.6.0,release-1.6.1:1.6.1,konveyor-dev:1.7.0,master:1.7.0,main:1.7.0'
+'release-1.3.2:1.3.z,release-1.4.4:1.4.4,release-1.4.3:1.4.3,release-1.4.0:1.4.0,release-1.4.5:1.4.5,release-1.4.6:1.4.6,release-1.4.7:1.4.7,release-1.5.0:1.5.0,release-1.5.1:1.5.1,release-1.5.2:1.5.2,release-1.5.3:1.5.3,release-1.6.0:1.6.0,release-1.6.1:1.6.1,release-1.6.2:1.6.2,konveyor-dev:1.7.0,master:1.7.0,main:1.7.0'
 ```
 


### PR DESCRIPTION
Update the map used in secrets.BRANCH_TO_RELEASE for our PR-BZ
automation GH actions.  This reflects what should be the most current
content for the secret.